### PR TITLE
Fix double ports on url

### DIFF
--- a/PrestaShop 1.6.x.x/oneallsociallogin/includes/tools.php
+++ b/PrestaShop 1.6.x.x/oneallsociallogin/includes/tools.php
@@ -799,6 +799,9 @@ class oneall_social_login_tools
 		$request_protocol = (self::is_https_on () ? 'https' : 'http');
 		$request_host = (isset ($_SERVER ['HTTP_X_FORWARDED_HOST']) ? $_SERVER ['HTTP_X_FORWARDED_HOST'] : (isset ($_SERVER ['HTTP_HOST']) ? $_SERVER ['HTTP_HOST'] : $_SERVER ['SERVER_NAME']));
 
+		// Make sure we strip $request_host so we got no double ports un $current_url
+		$request_host = preg_replace('/:?\d?\d?\d?\d?\d$/', '', $request_host);
+
 		//We are using a proxy
 		if (isset ($_SERVER ['HTTP_X_FORWARDED_PORT']))
 		{

--- a/PrestaShop 1.6.x.x/oneallsociallogin/includes/tools.php
+++ b/PrestaShop 1.6.x.x/oneallsociallogin/includes/tools.php
@@ -800,7 +800,7 @@ class oneall_social_login_tools
 		$request_host = (isset ($_SERVER ['HTTP_X_FORWARDED_HOST']) ? $_SERVER ['HTTP_X_FORWARDED_HOST'] : (isset ($_SERVER ['HTTP_HOST']) ? $_SERVER ['HTTP_HOST'] : $_SERVER ['SERVER_NAME']));
 
 		// Make sure we strip $request_host so we got no double ports un $current_url
-		$request_host = preg_replace('/:?\d?\d?\d?\d?\d$/', '', $request_host);
+		$request_host = preg_replace('/:?\d?\d?\d?\d?\d?$/', '', $request_host);
 
 		//We are using a proxy
 		if (isset ($_SERVER ['HTTP_X_FORWARDED_PORT']))


### PR DESCRIPTION
if the server runs on a port other than 80 (as might be common on a development/intranet machine) then HTTP_HOST contains the port, while SERVER_NAME does not.

http://stackoverflow.com/a/12046836/2248373
